### PR TITLE
javax-annotation-fixes for java 11, 17 and 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,4 +55,42 @@
         <microservice.mainClass>org.wso2.sample.Application</microservice.mainClass>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.117.Final</version>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
These new dependencies have been added to address the compilation issues and warnings caused by the absence of 'javax.xml.bind.annotation' after Java 9. I have tested these changes with Java versions 11, 17, and 21.